### PR TITLE
Add missing script tag for auth0-variables.js

### DIFF
--- a/01-Login/index.html
+++ b/01-Login/index.html
@@ -8,6 +8,7 @@
     <!-- Auth0 lock script -->
     <script src="//cdn.auth0.com/js/lock/10.1.0/lock.min.js"></script>
 
+    <script src="auth0-variables.js"></script>
     <script src="app.js"></script>
 
     <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
Without this, the **01-Login** sample will not work as the `AUTH0_CLIENT_ID` and `AUTH0_DOMAIN` variables will be empty. When downloaded as a seed project from the jQuery SPA QuickStart in the Auth0 website, the `auth0-variables.js` file gets automatically generated with these values.

Now if someone were to use this sample directly from GitHub (i.e. not download it as a QuickStrat), then this change doesn't make as much sense. Ideally the QuickStart packager (which generates the `auth0-variables.js` file) would also somehow edit the `index.html` page to add the script tag. But I'm not sure if that's possible.
